### PR TITLE
fix(tenant): tenant soft-deleted non routable + gel des mutations (#30)

### DIFF
--- a/apps/web/src/app/[domain]/admin/general/actions.ts
+++ b/apps/web/src/app/[domain]/admin/general/actions.ts
@@ -103,6 +103,12 @@ export const deleteTenant = async (): Promise<ServerActionResponse> => {
       },
       reqCtx,
     );
+
+    // Le routing résout les domaines via GetTenantForDomain (cache 1h) : on l'invalide pour que le
+    // tenant soft-deleted cesse d'être routable sans attendre l'expiration.
+    // NB : cache LRU process-local. En multi-instance, les autres process gardent l'ancien
+    // résultat jusqu'à expiration (acceptable single-instance Coolify ; sinon Redis pub/sub).
+    GetTenantForDomain.revalidate("GetTenantForDomain");
     return { ok: true };
   } catch (error) {
     const message = (error as Error).message;

--- a/apps/web/src/app/admin/(ee)/organizations/[orgId]/actions.ts
+++ b/apps/web/src/app/admin/(ee)/organizations/[orgId]/actions.ts
@@ -9,6 +9,7 @@ import { isGouvDomain } from "@/lib/ee/domain-verification";
 import { orgAddonRepo, orgDomainRepo, organizationRepo } from "@/lib/repo";
 import { type AddonType, type OrgPlan } from "@/prisma/enums";
 import { ToggleOrgAddon } from "@/useCases/ee/organization/ToggleOrgAddon";
+import { GetTenantForDomain } from "@/useCases/tenant/GetTenantForDomain";
 import { audit, AuditAction, getRequestContext } from "@/utils/audit";
 import { assertAdmin } from "@/utils/auth";
 import { type ServerActionResponse } from "@/utils/next";
@@ -209,6 +210,10 @@ export const deleteOrganizationAdmin = async (data: {
       },
       reqCtx,
     );
+
+    // Les tenants de l'org viennent d'être soft-deleted : on invalide le cache de routing
+    // (GetTenantForDomain, TTL 1h) pour qu'ils cessent d'être routables immédiatement.
+    GetTenantForDomain.revalidate("GetTenantForDomain");
     revalidatePath("/admin/organizations");
     return { ok: true };
   } catch (error) {

--- a/apps/web/src/lib/repo/impl/IntegrationRepoPrisma.ts
+++ b/apps/web/src/lib/repo/impl/IntegrationRepoPrisma.ts
@@ -24,21 +24,26 @@ export class IntegrationRepoPrisma implements IIntegrationRepo {
       where: {
         type: "GITHUB",
         enabled: true,
+        // Un tenant soft-deleted ne doit plus recevoir de webhook entrant (mutation sur tenant supprimé).
+        tenant: { deletedAt: null },
         config: { path: ["installationId"], equals: installationId },
       },
     });
   }
 
   public findDueForSync(): Promise<TenantIntegration[]> {
+    // JOIN sur Tenant + deletedAt IS NULL : un tenant soft-deleted ne doit plus être synchronisé par le cron.
     return prisma.$queryRaw<TenantIntegration[]>`
-      SELECT * FROM "TenantIntegration"
-      WHERE "enabled" = true
-        AND "syncIntervalMinutes" IS NOT NULL
+      SELECT ti.* FROM "TenantIntegration" ti
+      JOIN "Tenant" t ON t.id = ti."tenantId"
+      WHERE ti."enabled" = true
+        AND t."deletedAt" IS NULL
+        AND ti."syncIntervalMinutes" IS NOT NULL
         AND (
-          "lastSyncAt" IS NULL
-          OR "lastSyncAt" + ("syncIntervalMinutes" || ' minutes')::interval < NOW()
+          ti."lastSyncAt" IS NULL
+          OR ti."lastSyncAt" + (ti."syncIntervalMinutes" || ' minutes')::interval < NOW()
         )
-      ORDER BY "lastSyncAt" ASC NULLS FIRST
+      ORDER BY ti."lastSyncAt" ASC NULLS FIRST
     `;
   }
 

--- a/apps/web/src/lib/repo/impl/TenantRepoPrisma.ts
+++ b/apps/web/src/lib/repo/impl/TenantRepoPrisma.ts
@@ -50,6 +50,7 @@ export class TenantRepoPrisma implements ITenantRepo {
   public findBySubdomain(subdomain: string): Promise<null | Tenant> {
     return prisma.tenant.findFirst({
       where: {
+        deletedAt: null,
         settings: {
           subdomain,
         },
@@ -60,6 +61,7 @@ export class TenantRepoPrisma implements ITenantRepo {
   public findByCustomDomain(customDomain: string): Promise<null | Tenant> {
     return prisma.tenant.findFirst({
       where: {
+        deletedAt: null,
         settings: {
           customDomain,
         },
@@ -70,6 +72,7 @@ export class TenantRepoPrisma implements ITenantRepo {
   public findByVerifiedCustomDomain(customDomain: string): Promise<null | Tenant> {
     return prisma.tenant.findFirst({
       where: {
+        deletedAt: null,
         settings: {
           customDomain,
           customDomainVerifiedAt: { not: null },

--- a/apps/web/tests/testdb/repos/IntegrationRepoPrisma.test.ts
+++ b/apps/web/tests/testdb/repos/IntegrationRepoPrisma.test.ts
@@ -1,0 +1,67 @@
+import { prisma } from "@/lib/db/prisma";
+import { IntegrationRepoPrisma } from "@/lib/repo/impl/IntegrationRepoPrisma";
+import { type Prisma } from "@/prisma/client";
+
+import { createTestTenant } from "../helpers";
+
+const repo = new IntegrationRepoPrisma();
+
+async function createTestIntegration(
+  tenantId: number,
+  overrides: Partial<Prisma.TenantIntegrationUncheckedCreateInput> = {},
+) {
+  const defaults: Prisma.TenantIntegrationUncheckedCreateInput = {
+    tenantId,
+    type: "GITHUB",
+    name: "Test integration",
+    config: { installationId: 12345 },
+    enabled: true,
+    syncIntervalMinutes: 60,
+  };
+  return prisma.tenantIntegration.create({ data: { ...defaults, ...overrides, tenantId } });
+}
+
+describe("IntegrationRepoPrisma", () => {
+  describe("findByGitHubInstallationId", () => {
+    it("finds an enabled GitHub integration by installation id", async () => {
+      const tenant = await createTestTenant();
+      const integration = await createTestIntegration(tenant.id, { config: { installationId: 999 } });
+
+      const found = await repo.findByGitHubInstallationId(999);
+
+      expect(found).not.toBeNull();
+      expect(found!.id).toBe(integration.id);
+    });
+
+    it("returns null when the tenant is soft-deleted", async () => {
+      const tenant = await createTestTenant();
+      await createTestIntegration(tenant.id, { config: { installationId: 888 } });
+      await prisma.tenant.update({ where: { id: tenant.id }, data: { deletedAt: new Date() } });
+
+      const found = await repo.findByGitHubInstallationId(888);
+
+      expect(found).toBeNull();
+    });
+  });
+
+  describe("findDueForSync", () => {
+    it("returns enabled integrations that are due", async () => {
+      const tenant = await createTestTenant();
+      const integration = await createTestIntegration(tenant.id, { lastSyncAt: null });
+
+      const due = await repo.findDueForSync();
+
+      expect(due.map(i => i.id)).toContain(integration.id);
+    });
+
+    it("excludes integrations whose tenant is soft-deleted", async () => {
+      const tenant = await createTestTenant();
+      const integration = await createTestIntegration(tenant.id, { lastSyncAt: null });
+      await prisma.tenant.update({ where: { id: tenant.id }, data: { deletedAt: new Date() } });
+
+      const due = await repo.findDueForSync();
+
+      expect(due.map(i => i.id)).not.toContain(integration.id);
+    });
+  });
+});

--- a/apps/web/tests/testdb/repos/TenantRepoPrisma.test.ts
+++ b/apps/web/tests/testdb/repos/TenantRepoPrisma.test.ts
@@ -1,3 +1,4 @@
+import { prisma } from "@/lib/db/prisma";
 import { TenantRepoPrisma } from "@/lib/repo/impl/TenantRepoPrisma";
 
 import { createTestMembership, createTestOrganization, createTestTenantWithSettings, createTestUser } from "../helpers";
@@ -69,6 +70,15 @@ describe("TenantRepoPrisma", () => {
 
       expect(found).toBeNull();
     });
+
+    it("returns null when the tenant is soft-deleted", async () => {
+      const { tenant } = await createTestTenantWithSettings({ subdomain: "deleted-sub" });
+      await prisma.tenant.update({ where: { id: tenant.id }, data: { deletedAt: new Date() } });
+
+      const found = await repo.findBySubdomain("deleted-sub");
+
+      expect(found).toBeNull();
+    });
   });
 
   describe("findByCustomDomain", () => {
@@ -83,6 +93,15 @@ describe("TenantRepoPrisma", () => {
 
     it("returns null for unknown custom domain", async () => {
       const found = await repo.findByCustomDomain("unknown.example.com");
+
+      expect(found).toBeNull();
+    });
+
+    it("returns null when the tenant is soft-deleted", async () => {
+      const { tenant } = await createTestTenantWithSettings({ customDomain: "deleted.example.com" });
+      await prisma.tenant.update({ where: { id: tenant.id }, data: { deletedAt: new Date() } });
+
+      const found = await repo.findByCustomDomain("deleted.example.com");
 
       expect(found).toBeNull();
     });
@@ -105,6 +124,18 @@ describe("TenantRepoPrisma", () => {
       await createTestTenantWithSettings({ customDomain: "unverified.example.com" });
 
       const found = await repo.findByVerifiedCustomDomain("unverified.example.com");
+
+      expect(found).toBeNull();
+    });
+
+    it("returns null when the tenant is soft-deleted", async () => {
+      const { tenant } = await createTestTenantWithSettings({
+        customDomain: "deleted-verified.example.com",
+        customDomainVerifiedAt: new Date(),
+      });
+      await prisma.tenant.update({ where: { id: tenant.id }, data: { deletedAt: new Date() } });
+
+      const found = await repo.findByVerifiedCustomDomain("deleted-verified.example.com");
 
       expect(found).toBeNull();
     });


### PR DESCRIPTION
Closes #30.

## Contexte

Un tenant soft-deleted (`Tenant.deletedAt != null`) restait routable et inscriptible côté public : les résolutions par domaine du `TenantRepo` (`findBySubdomain`, `findByCustomDomain`, `findByVerifiedCustomDomain`) ne filtraient pas `deletedAt`, contrairement aux méthodes admin (`countByOrganizationId`, `findAllWithSettings`). Le soft-delete ne gelait donc rien côté public, ce qui bloque le flow de suppression manuelle de la source après une migration cross-instance.

L'analyse a montré que le problème dépasse les deux `where` cités dans l'issue : il y a aussi un cache de routing à invalider et deux chemins de mutation hors-routing à fermer.

## Changements

- **Routing (cause racine)** — `deletedAt IS NULL` sur les 3 résolutions par domaine du `TenantRepo`. Chokepoint unique : tous les chemins de routing passent par là (`getTenantFromDomain`/`GetTenantForDomain`, `auth.ts`, `auth-bridge`, `canonical-redirect`, `domains/check`, `subdomain/check`), ils tombent donc tous en 404/null automatiquement. Le check de conflit de domaine dans `UpdateTenantDomain` passe par `prisma.tenantSettings` directement (pas le repo) et reste volontairement non filtré, sinon on rouvrirait le hijacking d'un `customDomain` libéré.
- **Invalidation cache** — `GetTenantForDomain` est caché 1h. Sans invalidation, un tenant supprimé resterait servi jusqu'à 1h malgré le filtre. Ajout de `GetTenantForDomain.revalidate(...)` sur `deleteTenant` et `deleteOrganizationAdmin`, aligné sur le pattern existant (`updateTenantDomain` / `verifyTenantCustomDomain`).
- **Gel des mutations hors-routing** — les chemins web interactifs sont couverts par le 404 (ils re-résolvent par domaine), mais le cron de sync (`findDueForSync`) et le webhook GitHub entrant (`findByGitHubInstallationId`) font confiance à un `tenantId` stocké et continuaient d'écrire sur un tenant supprimé. Filtrés à la source du repo (JOIN / relation sur `Tenant.deletedAt`) ; les handlers gèrent déjà le null/vide proprement (cron skip, webhook `skipped`).
- **Tests testdb** — non-régression sur `TenantRepoPrisma` (3 cas) et nouveau fichier `IntegrationRepoPrisma.test.ts` (4 cas).

## Hors-scope

L'undelete : aucun flow de restauration n'existe aujourd'hui (l'`Organization` n'a pas de `deletedAt`, elle est hard-delete + cascade soft-delete des tenants ; l'admin root filtre déjà les soft-deleted). Le soft-delete devient donc irréversible sans intervention DB, ce qui colle à l'intention "gel". Une UI de restauration serait une feature séparée.

## Vérification

- `pnpm lint` clean
- `pnpm build` (typecheck) OK
- testdb 24/24 (dont les nouveaux cas soft-deleted), testi 11/11 (`DeleteTenant` + `GetTenantForDomain`)
