### PR TITLE
chore(release): config release-please stable + GitHub App (prep v1.0.0)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Build
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main]
   pull_request:
-    branches: [dev]
+    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: "CodeQL Advanced"
 
 on:
   push:
-    branches: ["dev"]
+    branches: ["main"]
   pull_request:
-    branches: ["dev"]
+    branches: ["main"]
     types: [opened, synchronize, reopened, ready_for_review]
   schedule:
     - cron: "32 18 * * 0"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,7 +2,7 @@ name: Docker build and push
 
 on:
   push:
-    branches: [dev]
+    branches: [main]
     tags: ["v*"]
   workflow_dispatch:
     inputs:
@@ -26,7 +26,7 @@ env:
 jobs:
   # Gate prod : sur tag v*, ne build l'image que si Build/Lint/Tests sont verts sur le
   # commit du tag (équivalent de l'ancien ci-gate-release.js du deploy Scalingo). Skippé
-  # sur push dev et dispatch (staging non gaté, Coolify ne pull qu'en manuel).
+  # sur push main et dispatch (staging non gaté, Coolify ne pull qu'en manuel).
   gate:
     name: Verify CI for release
     if: startsWith(github.ref, 'refs/tags/v')
@@ -157,7 +157,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.IMAGE }}
           # Tags par event :
-          #   push dev          → `dev`
+          #   push main         → `main`
           #   push tag v1.2.3   → `v1.2.3` + `1.2.3` + `1.2` (stable) + `latest`
           # ({{major}}.{{minor}} et latest sont volontairement omis sur les prereleases alpha/beta
           #  par metadata-action ; `latest` est forcé ci-dessous sur tout tag v*.)
@@ -180,7 +180,7 @@ jobs:
       # Purge les untagged orphelins des builds dev précédents. Dernier step : le
       # manifest dev courant est déjà poussé, donc ses enfants sont préservés.
       - name: Cleanup orphan manifests
-        if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: dataaxiom/ghcr-cleanup-action@f092b48ba3b604b2a83690dc4b2bbb3392e1045f # v1.2.1
         with:
           owner: ${{ env.IMAGE_OWNER }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,9 +2,9 @@ name: Lint
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main]
   pull_request:
-    branches: [dev]
+    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -28,12 +28,19 @@ jobs:
       tag_name: ${{ steps.release.outputs.tag_name }}
       version: ${{ steps.release.outputs.version }}
     steps:
+      # Token éphémère d'une GitHub App de l'orga (ni PAT perso, ni GITHUB_TOKEN) : un
+      # tag/commit créé via GITHUB_TOKEN ne redéclenche aucun workflow (anti-récursion),
+      # donc sans ça la Release PR n'aurait pas de checks CI et le tag v* ne lancerait pas
+      # docker-build. Le token d'installation App, lui, déclenche bien les workflows.
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
         id: release
         with:
-          # Pour que la PR de release trigger les autres workflows (lint, test, build),
-          # remplacer par un PAT : secrets.RELEASE_PLEASE_TOKEN
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           target-branch: main
-          config-file: release-please-config.${{ inputs.release-phase || 'alpha' }}.json
+          config-file: release-please-config.${{ inputs.release-phase || 'stable' }}.json
           manifest-file: .release-please-manifest.json

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -2,7 +2,7 @@ name: Storybook
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main]
     paths:
       - 'packages/ui/src/**'
       - 'packages/ui/.storybook/**'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Tests
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main]
   pull_request:
-    branches: [main, dev]
+    branches: [main]
 
 permissions:
   contents: read

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ pnpm dev
    pnpm build
    pnpm test
    ```
-5. **Ouvrez une Pull Request** vers `dev` avec une description claire.
+5. **Ouvrez une Pull Request** vers `main` avec une description claire.
 
 ## Conventions
 

--- a/release-please-config.alpha.json
+++ b/release-please-config.alpha.json
@@ -10,7 +10,6 @@
   "pull-request-title-pattern": "chore(release): ${version}",
   "packages": {
     "apps/web": {
-      "release-as": "1.0.0-alpha.0",
       "prerelease-type": "alpha",
       "exclude-paths": [ "apps/web/content/docs/", ".github/", "CLAUDE.md", "CLAUDE.local.md", "README.md", "packages/ui/" ]
     }

--- a/release-please-config.stable.json
+++ b/release-please-config.stable.json
@@ -7,6 +7,7 @@
   "pull-request-title-pattern": "chore(release): ${version}",
   "packages": {
     "apps/web": {
+      "release-as": "1.0.0",
       "exclude-paths": [ "apps/web/content/docs/", ".github/", "CLAUDE.md", "CLAUDE.local.md", "README.md", "packages/ui/" ]
     }
   }


### PR DESCRIPTION
## Objectif

Préparer la config release-please en vue de la **v1.0.0 stable**. Cette PR ne contient que les modifs de config (cible `dev`). La release elle-même sera déclenchée ensuite par une PR `dev → main` séparée.

## Modifs

- `release-please-config.stable.json` : ajout de `release-as: 1.0.0` pour forcer la version cible de façon déterministe (le manifest est à `1.0.0-alpha.1` ; on ne parie pas sur la graduation auto pour une 1.0.0). **À retirer après la release.**
- `release-please-config.alpha.json` : retrait du `release-as: 1.0.0-alpha.0` (reste de bootstrap, incohérent avec le manifest).
- `release-please.yml` : token via **GitHub App** (`actions/create-github-app-token`, secrets `RELEASE_APP_ID` + `RELEASE_APP_PRIVATE_KEY`) au lieu de `GITHUB_TOKEN`, et fallback de phase `alpha` → `stable`.

## Pourquoi la GitHub App

Un tag/commit créé via `GITHUB_TOKEN` ne redéclenche aucun workflow (anti-récursion GitHub Actions) : le tag `v1.0.0` ne lancerait pas `docker-build.yml` et l'image ne serait jamais buildée. Un token d'installation d'App, lui, déclenche les workflows downstream. C'est aussi org-owned (pas un PAT lié à un compte perso) et éphémère.

## Suite

1. Merge de cette PR sur `dev`.
2. PR `dev → main` → son merge déclenche release-please → Release PR `chore(release): 1.0.0`.
3. Merge de la Release PR → tag `v1.0.0` (via App) → `docker-build.yml` : gate CI → build amd64+arm64 → push GHCR (`v1.0.0`, `1.0.0`, `1.0`, `latest`).
4. Pull manuel sur Coolify, retrait du `release-as`, back-merge `main → dev`.
