### PR TITLE
ci(docker-build): fix race cleanup + bump actions Node 24 + skip check Dockerfile

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -15,9 +15,12 @@ on:
 permissions:
   contents: read
 
+# Sérialisé globalement (group commun, sans annulation) : le job merge pousse les images
+# par arch en untagged avant d'assembler le manifest taggé ; un run concurrent dont le step
+# cleanup fait delete-untagged supprimerait ces digests en vol (race observée sur la v1.0.0).
 concurrency:
-  cancel-in-progress: true
-  group: docker-build-${{ github.ref }}
+  cancel-in-progress: false
+  group: docker-build
 
 env:
   REGISTRY: ghcr.io
@@ -36,12 +39,12 @@ jobs:
       actions: read
     steps:
       - name: Checkout gate script
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           sparse-checkout: .github/scripts
           sparse-checkout-cone-mode: false
       - name: Verify CI workflows passed for tagged commit
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const gate = require('./.github/scripts/ci-gate-release.js');
@@ -67,13 +70,13 @@ jobs:
       IMAGE: roadmaps-faciles-web
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -81,7 +84,7 @@ jobs:
 
       - name: Image labels
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.IMAGE }}
           labels: |
@@ -92,7 +95,7 @@ jobs:
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: ./Dockerfile
@@ -115,7 +118,7 @@ jobs:
 
       - name: Upload digest
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.push }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: digests-${{ matrix.arch }}
           path: /tmp/digests/*
@@ -135,17 +138,17 @@ jobs:
       IMAGE: roadmaps-faciles-web
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: /tmp/digests
           pattern: digests-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -153,7 +156,7 @@ jobs:
 
       - name: Extract metadata (tags)
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.IMAGE }}
           # Tags par event :

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,9 @@
 # syntax=docker/dockerfile:1
+# check=skip=SecretsUsedInArgOrEnv
+#
+# check=skip ci-dessus : ESPACE_MEMBRE_API_KEY (plus bas) est un placeholder build
+# (fakesecret), la vraie clé est injectée au runtime — faux positif. Vrai fix = lazy-init
+# du client pour ne plus dépendre de l'env var au build (cf TODO sur le ARG).
 #
 # Image multi-usage :
 #   - SaaS prod (roadmaps-faciles.fr) : déployée avec Dockerfile.licensing à côté


### PR DESCRIPTION
## Fix CI : race du pipeline docker-build + warnings

### 1. Race condition `docker-build` (la cause de l'échec du build de la v1.0.0)

Au merge de la Release PR, deux runs `docker-build` démarrent en parallèle : le push `main` (image staging) et le tag `v*`. Le run `main` se termine par un `Cleanup orphan manifests` (`delete-untagged: true`) qui supprimait les images par-arch poussées **par digest** (donc untagged) du run `v*` pendant qu'il assemblait encore son manifest → `manifest ... not found`.

Fix : `concurrency` passé à `group: docker-build` (commun) + `cancel-in-progress: false`, ce qui **sérialise** les runs `docker-build`. Plus aucun cleanup concurrent possible.

### 2. Warnings Node 20 → bump des actions vers Node 24

`checkout v4→v7.0.0`, `github-script v7→v9.0.0` (pin SHA conservé), `upload-artifact v4→v7.0.1`, `download-artifact v4→v8.0.1`, `docker/build-push v6→v7.2.0`, `docker/login v3→v4.2.0`, `docker/metadata v5→v6.1.0`, `docker/setup-buildx v3→v4.1.0`. Versions vérifiées comme tournant sur `node24` dans leur `action.yml`.

### 3. Warning secrets Dockerfile

`# check=skip=SecretsUsedInArgOrEnv` : `ESPACE_MEMBRE_API_KEY` au build est un placeholder (`fakesecret`), la vraie clé est injectée au runtime. Faux positif. Le vrai fix (lazy-init du client pour ne plus dépendre de l'env var au build) reste un TODO séparé.

### Validation

`docker-build` ne tourne pas sur les PRs (seulement push `main` + tags). Les bumps d'actions (notamment `upload`/`download-artifact` v4→v7/v8) sont validés via un `workflow_dispatch` sur cette branche avant merge.

### Hors scope (à décider)

D'autres workflows (`build`, `lint`, `test`, `storybook`, `codeql`) utilisent encore des actions Node 20 (`checkout@v4`, `setup-node@v4`, `cache@v4`, etc.). À bumper dans une passe séparée si on veut éliminer tous les warnings.
