### PR TITLE
ci(release-please): pin create-github-app-token par SHA (v3.2.0)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,7 +32,7 @@ jobs:
       # tag/commit créé via GITHUB_TOKEN ne redéclenche aucun workflow (anti-récursion),
       # donc sans ça la Release PR n'aurait pas de checks CI et le tag v* ne lancerait pas
       # docker-build. Le token d'installation App, lui, déclenche bien les workflows.
-      - uses: actions/create-github-app-token@v2
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}


### PR DESCRIPTION
Suite à la review de #39 : `actions/create-github-app-token` était la dernière action non pinnée par SHA du repo (et en `@v2` = Node 20). Passée en **v3.2.0 pinnée par SHA** (Node 24).

Désormais **100% des actions du repo sont pinnées par SHA + Node 24**. Validé au merge : le push sur `main` relance release-please, qui utilise cette action.