### PR TITLE
fix(espace-membre): retire la dépendance build à la clé

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,4 @@ jobs:
           restore-keys: |
             turbo-build-${{ runner.os }}-
       - name: Build and export
-        env:
-          ESPACE_MEMBRE_API_KEY: fakesecret
         run: pnpm build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,4 @@
 # syntax=docker/dockerfile:1
-# check=skip=SecretsUsedInArgOrEnv
-#
-# check=skip ci-dessus : ESPACE_MEMBRE_API_KEY (plus bas) est un placeholder build
-# (fakesecret), la vraie clé est injectée au runtime — faux positif. Vrai fix = lazy-init
-# du client pour ne plus dépendre de l'env var au build (cf TODO sur le ARG).
 #
 # Image multi-usage :
 #   - SaaS prod (roadmaps-faciles.fr) : déployée avec Dockerfile.licensing à côté
@@ -47,10 +42,6 @@ ARG NEXT_PUBLIC_APP_VERSION
 # SOURCE_COMMIT pour GHA/Coolify (cf next.config.ts qui accepte les 2).
 ARG SOURCE_COMMIT
 ENV SOURCE_COMMIT=${SOURCE_COMMIT}
-
-# TODO: lazy-init du client pour ne pas dépendre d'env var au build.
-ARG ESPACE_MEMBRE_API_KEY=fakesecret
-ENV ESPACE_MEMBRE_API_KEY=${ESPACE_MEMBRE_API_KEY}
 
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/apps/web/node_modules ./apps/web/node_modules

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -44,7 +44,7 @@
     "@github/text-expander-element": "^2.9.4",
     "@hookform/resolvers": "^5.2.2",
     "@icons-pack/react-simple-icons": "^13.13.0",
-    "@incubateur-ademe/next-auth-espace-membre-provider": "^0.3.3",
+    "@incubateur-ademe/next-auth-espace-membre-provider": "^0.3.4",
     "@mdx-js/react": "^3.1.1",
     "@mui/lab": "7.0.1-beta.23",
     "@mui/material": "^7.3.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -194,8 +194,8 @@ importers:
         specifier: ^13.13.0
         version: 13.13.0(react@19.2.6)
       '@incubateur-ademe/next-auth-espace-membre-provider':
-        specifier: ^0.3.3
-        version: 0.3.3(next-auth@5.0.0-beta.30(@simplewebauthn/browser@13.3.0)(@simplewebauthn/server@13.3.0)(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(nodemailer@9.0.1)(react@19.2.6))
+        specifier: ^0.3.4
+        version: 0.3.4(next-auth@5.0.0-beta.30(@simplewebauthn/browser@13.3.0)(@simplewebauthn/server@13.3.0)(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(nodemailer@9.0.1)(react@19.2.6))
       '@mdx-js/react':
         specifier: ^3.1.1
         version: 3.1.1(@types/react@19.2.15)(react@19.2.6)
@@ -1468,8 +1468,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@incubateur-ademe/next-auth-espace-membre-provider@0.3.3':
-    resolution: {integrity: sha512-VFgyBC22FaZrmQsfT0FZjX0bK1qtkPCrOAkjfJrI/kIF0rg0VWTVBg1AkeXryH1QAGGHkI012CHaPPjN0MzexQ==}
+  '@incubateur-ademe/next-auth-espace-membre-provider@0.3.4':
+    resolution: {integrity: sha512-Whskxy7SAdN24UwuW/X2oAEN9QZYh+HDFDwKubNLyUId1JEsEDKCPybzrQgzDdI8taXxcjoQ/f+hDaN3DMpDRQ==}
     peerDependencies:
       next-auth: '>=5.0.0-0'
 
@@ -10461,7 +10461,7 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
-  '@incubateur-ademe/next-auth-espace-membre-provider@0.3.3(next-auth@5.0.0-beta.30(@simplewebauthn/browser@13.3.0)(@simplewebauthn/server@13.3.0)(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(nodemailer@9.0.1)(react@19.2.6))':
+  '@incubateur-ademe/next-auth-espace-membre-provider@0.3.4(next-auth@5.0.0-beta.30(@simplewebauthn/browser@13.3.0)(@simplewebauthn/server@13.3.0)(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(nodemailer@9.0.1)(react@19.2.6))':
     dependencies:
       next-auth: 5.0.0-beta.30(@simplewebauthn/browser@13.3.0)(@simplewebauthn/server@13.3.0)(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(nodemailer@9.0.1)(react@19.2.6)
 
@@ -14747,7 +14747,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.6
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
@@ -14781,7 +14781,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -14811,14 +14811,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -14861,7 +14861,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       hasown: 2.0.3
       is-core-module: 2.16.2
       is-glob: 4.0.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -53,3 +53,5 @@ allowBuilds:
   protobufjs: true
   sharp: true
   unrs-resolver: true
+minimumReleaseAgeExclude:
+  - '@incubateur-ademe/next-auth-espace-membre-provider@0.3.4'


### PR DESCRIPTION
Vrai fix du TODO de #38 (la directive `check=skip=SecretsUsedInArgOrEnv` du Dockerfile).

### Problème
Le build dépendait d'une fausse clé `ESPACE_MEMBRE_API_KEY=fakesecret` (Dockerfile + build.yml + test.yml) car `EspaceMembreClient` throw sur clé vide **dans son constructeur**, et le provider NextAuth (`auth.ts`) l'instancie au module-load (eager), que Next évalue au build → throw.

### Fix (à la source, dans la lib)
`@incubateur-ademe/next-auth-espace-membre-provider@0.3.4` déplace la validation de la clé du **constructeur** vers **`makeRequest`** (le moment de l'appel réel). Instancier le client ne throw plus ; seul un vrai appel sans clé échoue → comportement runtime identique, build débloqué pour tous les consommateurs.

Côté roadmaps-faciles, il ne reste donc que :
- bump `@incubateur-ademe/next-auth-espace-membre-provider` `0.3.3` → `0.3.4`
- retrait du `ARG`/`ENV ESPACE_MEMBRE_API_KEY` + directive `check=skip` du Dockerfile
- retrait du `fakesecret` de `build.yml` / `test.yml`

(pnpm a ajouté `0.3.4` à `minimumReleaseAgeExclude` car la version vient d'être publiée.)

### Validation
Le **build CI tourne sans `fakesecret`** : c'est lui qui valide qu'il n'y a plus de dépendance build à la clé (+ Unit/DB/E2E).
