### PR TITLE
fix(metadata): cacher l'exposition des posts non approuvés dans les métadonnées

### DIFF
--- a/apps/web/src/lib/utils/metadata.ts
+++ b/apps/web/src/lib/utils/metadata.ts
@@ -2,6 +2,7 @@ import { type Metadata } from "next";
 
 import { config } from "@/config";
 import { prisma } from "@/lib/db/prisma";
+import { POST_APPROVAL_STATUS } from "@/lib/model/Post";
 import { getTenantFromDomain } from "@/utils/tenant";
 
 /**
@@ -137,6 +138,7 @@ export const generatePostMetadata = async (domain: string, postId: string): Prom
       select: {
         title: true,
         description: true,
+        approvalStatus: true,
         board: { select: { name: true } },
         user: { select: { name: true } },
         createdAt: true,
@@ -144,7 +146,7 @@ export const generatePostMetadata = async (domain: string, postId: string): Prom
     }),
   ]);
 
-  if (!settings || !post) return {};
+  if (!settings || !post || post.approvalStatus !== POST_APPROVAL_STATUS.APPROVED) return {};
 
   const description = truncateDescription(post.description) || `${post.title} - ${settings.name}`;
   const url = buildTenantUrl(settings.subdomain, settings.customDomain, `/post/${id}`);

--- a/apps/web/tests/testi/metadata/generatePostMetadata.test.ts
+++ b/apps/web/tests/testi/metadata/generatePostMetadata.test.ts
@@ -1,0 +1,65 @@
+const mockGetTenantFromDomain = vi.fn();
+vi.mock("@/utils/tenant", () => ({
+  getTenantFromDomain: (...args: unknown[]) => mockGetTenantFromDomain(...args),
+}));
+
+const mockSettingsFindFirst = vi.fn();
+const mockPostFindUnique = vi.fn();
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: {
+    tenantSettings: { findFirst: (...args: unknown[]) => mockSettingsFindFirst(...args) },
+    post: { findUnique: (...args: unknown[]) => mockPostFindUnique(...args) },
+  },
+}));
+
+vi.mock("@/config", () => ({
+  config: { host: "https://roadmaps-faciles.fr" },
+}));
+
+const { generatePostMetadata } = await import("@/utils/metadata");
+
+const TENANT = { id: 1 };
+const SETTINGS = { name: "TACCT", subdomain: "tacct", customDomain: null };
+const basePost = {
+  title: "Public roadmap post",
+  description: "A normal public description",
+  board: { name: "feature" },
+  user: { name: "Alice" },
+  createdAt: new Date("2026-06-29T00:00:00.000Z"),
+};
+
+describe("generatePostMetadata", () => {
+  beforeEach(() => {
+    mockGetTenantFromDomain.mockReset();
+    mockSettingsFindFirst.mockReset();
+    mockPostFindUnique.mockReset();
+    mockGetTenantFromDomain.mockResolvedValue(TENANT);
+    mockSettingsFindFirst.mockResolvedValue(SETTINGS);
+  });
+
+  it("exposes metadata for an approved post", async () => {
+    mockPostFindUnique.mockResolvedValue({ ...basePost, approvalStatus: "APPROVED" });
+    const meta = await generatePostMetadata("tacct.roadmaps-faciles.fr", "113");
+    expect(meta.title).toBe("Public roadmap post");
+  });
+
+  // Regression: posts pending moderation must not leak title/description via OG tags.
+  it("does NOT expose metadata for a pending (unmoderated) post", async () => {
+    mockPostFindUnique.mockResolvedValue({ ...basePost, title: "PENDING-SECRET", approvalStatus: "PENDING" });
+    const meta = await generatePostMetadata("tacct.roadmaps-faciles.fr", "113");
+    expect(meta).toEqual({});
+    expect(JSON.stringify(meta)).not.toContain("PENDING-SECRET");
+  });
+
+  it("does NOT expose metadata for a rejected post", async () => {
+    mockPostFindUnique.mockResolvedValue({ ...basePost, title: "REJECTED-SECRET", approvalStatus: "REJECTED" });
+    const meta = await generatePostMetadata("tacct.roadmaps-faciles.fr", "113");
+    expect(meta).toEqual({});
+  });
+
+  it("returns empty metadata when the post does not exist", async () => {
+    mockPostFindUnique.mockResolvedValue(null);
+    const meta = await generatePostMetadata("tacct.roadmaps-faciles.fr", "999");
+    expect(meta).toEqual({});
+  });
+});


### PR DESCRIPTION
## Le problème
`generatePostMetadata` (apps/web/src/lib/utils/metadata.ts) récupère un post par
`id` sans filtrer `approvalStatus`, puis expose `title` + `description` dans le
`<head>` (`<title>`, `og:title`, `og:description`).

Or les posts `PENDING` (modération) ou `REJECTED` ne sont pas publics : le board
les filtre et `/post/[postId]` renvoie `notFound()` pour les non-admins/non-auteurs.
La metadata ne respectait pas ce gate → titre + description (~160 car.) d'un post
non publié fuitaient à un visiteur **non authentifié**. Réponse servie en `200`
(pas `404`) → **indexable par les moteurs de recherche**.

## Impact
Contournement de la modération : titre + extrait de description d'un post non
approuvé deviennent lisibles et indexables publiquement. Portée limitée au titre
et ~160 car. de description (le corps, les commentaires et les autres champs ne
fuitent pas — la page protège bien le body).

## Repro
1. Tenant avec « Approbation des posts requise » activée.
2. Créer un post → reste `PENDING` (caché du board).
3. `GET /post/<id>` anonyme : `<title>`/`og:*` exposent le post, corps non rendu, status `200`.

## Correctif
Aligner la metadata sur la visibilité de la page : ne rien exposer si le post
n'est pas `APPROVED`.

## Test
`tests/testi/metadata/generatePostMetadata.test.ts` : un post `PENDING`/`REJECTED`
ne produit aucune métadonnée ; un post `APPROVED` reste exposé normalement.
